### PR TITLE
fix: patch postcss GHSA-qx2v-qp2m-jg93 moderate vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2356,32 +2356,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.46",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "react-vertical-timeline-component": "^4.0.0",
     "resend": "^6.12.4"
   },
+  "overrides": {
+    "postcss": "^8.5.15"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
     "@tailwindcss/postcss": "^4.3.0",


### PR DESCRIPTION
## Problem

`next@16.2.6` ships with a nested `postcss@8.4.31` which is affected by **GHSA-qx2v-qp2m-jg93** (PostCSS XSS via unescaped `</style>` in CSS stringify output, moderate severity).

`npm audit fix --force` is not viable — it would downgrade `next` to 9.3.3.

## Fix

Add an `overrides` field in `package.json` to force all transitive `postcss` resolutions to `>=8.5.15`:

```json
"overrides": {
  "postcss": "^8.5.15"
}
```

This deduplicates `next`'s nested install so it uses the already-present top-level `postcss@8.5.15`.

## Verification

- [x] `npm audit` → **found 0 vulnerabilities**
- [x] `npm list postcss` → all instances resolve to `8.5.15`
- [x] `bun lint` passes
- [x] `bun run build` succeeds